### PR TITLE
Permit configurable --xlator-dir for glusterfsd

### DIFF
--- a/api/src/Makefile.am
+++ b/api/src/Makefile.am
@@ -25,7 +25,7 @@ libgfapi_la_LDFLAGS = -version-info $(GFAPI_LT_VERSION) \
 	$(GFAPI_EXTRA_LDFLAGS) $(ACL_LIBS)
 
 xlator_LTLIBRARIES = api.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/mount
+xlatordir = $(libdir)/glusterfs/xlator/mount
 # workaround for broken parallel install support in automake with LTLIBRARIES
 # http://debbugs.gnu.org/cgi/bugreport.cgi?bug=7328
 install_xlatorLTLIBRARIES = install-xlatorLTLIBRARIES

--- a/api/src/glfs-mgmt.c
+++ b/api/src/glfs-mgmt.c
@@ -52,7 +52,7 @@ glfs_process_volfp (struct glfs *fs, FILE *fp)
 	glusterfs_ctx_t	   *ctx = NULL;
 
 	ctx = fs->ctx;
-	graph = glusterfs_graph_construct (fp);
+	graph = glusterfs_graph_construct (fp, ctx);
 	if (!graph) {
 		gf_msg ("glfs", GF_LOG_ERROR, errno,
                         API_MSG_GRAPH_CONSTRUCT_FAILED,

--- a/extras/create_new_xlator/generate_xlator.py
+++ b/extras/create_new_xlator/generate_xlator.py
@@ -10,7 +10,7 @@ from generator import ops, xlator_cbks, xlator_dumpops
 
 MAKEFILE_FMT = """
 xlator_LTLIBRARIES = @XL_NAME@.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/@XL_TYPE@
+xlatordir = $(libdir)/glusterfs/xlator/@XL_TYPE@
 @XL_NAME_NO_HYPHEN@_la_LDFLAGS = -module -avoid-version
 @XL_NAME_NO_HYPHEN@_la_SOURCES = @XL_NAME@.c
 @XL_NAME_NO_HYPHEN@_la_LIBADD = $(top_builddir)/libglusterfs/src/libglusterfs.la

--- a/glusterfsd/src/Makefile.am
+++ b/glusterfsd/src/Makefile.am
@@ -17,7 +17,7 @@ noinst_HEADERS = glusterfsd.h glusterfsd-mem-types.h glusterfsd-messages.h
 AM_CPPFLAGS = $(GF_CPPFLAGS) \
 	-I$(top_srcdir)/libglusterfs/src -DDATADIR=\"$(localstatedir)\" \
 	-DCONFDIR=\"$(sysconfdir)/glusterfs\" $(GF_GLUSTERFS_CFLAGS) \
-	-DXLATORDIR=\"$(libdir)/glusterfs/xlator\" \
+	-DXLATORDEFAULTDIR=\"$(libdir)/glusterfs/xlator\" \
 	-I$(top_srcdir)/rpc/rpc-lib/src \
 	-I$(top_srcdir)/rpc/xdr/src \
 	-I$(top_builddir)/rpc/xdr/src \

--- a/glusterfsd/src/Makefile.am
+++ b/glusterfsd/src/Makefile.am
@@ -17,7 +17,7 @@ noinst_HEADERS = glusterfsd.h glusterfsd-mem-types.h glusterfsd-messages.h
 AM_CPPFLAGS = $(GF_CPPFLAGS) \
 	-I$(top_srcdir)/libglusterfs/src -DDATADIR=\"$(localstatedir)\" \
 	-DCONFDIR=\"$(sysconfdir)/glusterfs\" $(GF_GLUSTERFS_CFLAGS) \
-	-DXLATORDIR=\"$(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator\" \
+	-DXLATORDIR=\"$(libdir)/glusterfs/xlator\" \
 	-I$(top_srcdir)/rpc/rpc-lib/src \
 	-I$(top_srcdir)/rpc/xdr/src \
 	-I$(top_builddir)/rpc/xdr/src \

--- a/glusterfsd/src/glusterfsd-mgmt.c
+++ b/glusterfsd/src/glusterfsd-mgmt.c
@@ -847,7 +847,8 @@ glusterfs_handle_attach (rpcsvc_request_t *req)
                 gf_log (this->name, GF_LOG_INFO,
                         "got attach for %s", xlator_req.name);
                 ret = glusterfs_graph_attach (this->ctx->active,
-                                              xlator_req.name, &newgraph);
+                                              xlator_req.name, &newgraph,
+                                              this->ctx);
                 if (ret == 0) {
                         ret = glusterfs_graph_parent_up (newgraph);
                         if (ret) {

--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -2352,7 +2352,7 @@ glusterfs_process_volfp (glusterfs_ctx_t *ctx, FILE *fp)
         xlator_t           *trav = NULL;
         int                 err = 0;
 
-        graph = glusterfs_graph_construct (fp);
+        graph = glusterfs_graph_construct (fp, ctx);
         if (!graph) {
                 gf_msg ("", GF_LOG_ERROR, 0, glusterfsd_msg_26);
                 goto out;

--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -1728,8 +1728,8 @@ print_exports_file (const char *exports_file)
         void (*exp_file_print)(const struct exports_file *file) = NULL;
         void (*exp_file_deinit)(struct exports_file *ptr) = NULL;
 
-        /* XLATORDIR passed through a -D flag to GCC */
-        ret = gf_asprintf (&libpathfull, "%s/%s/server.so", XLATORDIR,
+        /* XLATORDEFAULTDIR passed through a -D flag to GCC */
+        ret = gf_asprintf (&libpathfull, "%s/%s/server.so", XLATORDEFAULTDIR,
                            "nfs");
         if (ret < 0) {
                 gf_log ("glusterfs", GF_LOG_CRITICAL, "asprintf () failed.");
@@ -1824,8 +1824,8 @@ print_netgroups_file (const char *netgroups_file)
         void         (*ng_file_print)(const struct netgroups_file *file) = NULL;
         void         (*ng_file_deinit)(struct netgroups_file *ptr) = NULL;
 
-        /* XLATORDIR passed through a -D flag to GCC */
-        ret = gf_asprintf (&libpathfull, "%s/%s/server.so", XLATORDIR,
+        /* XLATORDEFAULTDIR passed through a -D flag to GCC */
+        ret = gf_asprintf (&libpathfull, "%s/%s/server.so", XLATORDEFAULTDIR,
                         "nfs");
         if (ret < 0) {
                 gf_log ("glusterfs", GF_LOG_CRITICAL, "asprintf () failed.");

--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -150,6 +150,8 @@ static struct argp_option gf_options[] = {
         {"volume-name", ARGP_VOLUME_NAME_KEY, "XLATOR-NAME", 0,
          "Translator name to be used for MOUNT-POINT [default: top most volume "
          "definition in VOLFILE]"},
+        {"xlator-dir", ARGP_XLATORDIR_OPTION_KEY, "XLATOR-DIR", 0,
+         "Directory to load xlators from [default: " XLATORDEFAULTDIR "]"},
         {"xlator-option", ARGP_XLATOR_OPTION_KEY,"XLATOR-NAME.OPTION=VALUE", 0,
          "Add/override an option for a translator in volume file with specified"
          " value"},
@@ -1077,6 +1079,10 @@ parse_opts (int key, char *arg, struct argp_state *state)
 
         case ARGP_VOLUME_NAME_KEY:
                 cmd_args->volume_name = gf_strdup (arg);
+                break;
+
+        case ARGP_XLATORDIR_OPTION_KEY:
+                cmd_args->xlator_dir = gf_strdup (arg);
                 break;
 
         case ARGP_XLATOR_OPTION_KEY:

--- a/glusterfsd/src/glusterfsd.h
+++ b/glusterfsd/src/glusterfsd.h
@@ -97,6 +97,7 @@ enum argp_option_keys {
         ARGP_OOM_SCORE_ADJ_KEY            = 176,
 #endif
         ARGP_FUSE_EVENT_HISTORY_KEY       = 177,
+        ARGP_XLATORDIR_OPTION_KEY         = 178,
 };
 
 struct _gfd_vol_top_priv_t {

--- a/libglusterfs/src/Makefile.am
+++ b/libglusterfs/src/Makefile.am
@@ -4,7 +4,7 @@ libglusterfs_la_CFLAGS = $(GF_CFLAGS) $(GF_DARWIN_LIBGLUSTERFS_CFLAGS) \
 	-DDATADIR=\"$(localstatedir)\"
 
 libglusterfs_la_CPPFLAGS = $(GF_CPPFLAGS) -D__USE_FILE_OFFSET64 \
-	-DXLATORDIR=\"$(libdir)/glusterfs/xlator\" \
+	-DXLATORDEFAULTDIR=\"$(libdir)/glusterfs/xlator\" \
 	-DXLATORPARENTDIR=\"$(libdir)/glusterfs\" \
 	-I$(top_srcdir)/rpc/xdr/src/ -I$(top_builddir)/rpc/xdr/src/ \
 	-I$(top_srcdir)/rpc/rpc-lib/src/ -I$(CONTRIBDIR)/rbtree \

--- a/libglusterfs/src/Makefile.am
+++ b/libglusterfs/src/Makefile.am
@@ -5,7 +5,6 @@ libglusterfs_la_CFLAGS = $(GF_CFLAGS) $(GF_DARWIN_LIBGLUSTERFS_CFLAGS) \
 
 libglusterfs_la_CPPFLAGS = $(GF_CPPFLAGS) -D__USE_FILE_OFFSET64 \
 	-DXLATORDEFAULTDIR=\"$(libdir)/glusterfs/xlator\" \
-	-DXLATORPARENTDIR=\"$(libdir)/glusterfs\" \
 	-I$(top_srcdir)/rpc/xdr/src/ -I$(top_builddir)/rpc/xdr/src/ \
 	-I$(top_srcdir)/rpc/rpc-lib/src/ -I$(CONTRIBDIR)/rbtree \
 	-I$(CONTRIBDIR)/libexecinfo ${ARGP_STANDALONE_CPPFLAGS} \

--- a/libglusterfs/src/Makefile.am
+++ b/libglusterfs/src/Makefile.am
@@ -4,8 +4,8 @@ libglusterfs_la_CFLAGS = $(GF_CFLAGS) $(GF_DARWIN_LIBGLUSTERFS_CFLAGS) \
 	-DDATADIR=\"$(localstatedir)\"
 
 libglusterfs_la_CPPFLAGS = $(GF_CPPFLAGS) -D__USE_FILE_OFFSET64 \
-	-DXLATORDIR=\"$(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator\" \
-	-DXLATORPARENTDIR=\"$(libdir)/glusterfs/$(PACKAGE_VERSION)\" \
+	-DXLATORDIR=\"$(libdir)/glusterfs/xlator\" \
+	-DXLATORPARENTDIR=\"$(libdir)/glusterfs\" \
 	-I$(top_srcdir)/rpc/xdr/src/ -I$(top_builddir)/rpc/xdr/src/ \
 	-I$(top_srcdir)/rpc/rpc-lib/src/ -I$(CONTRIBDIR)/rbtree \
 	-I$(CONTRIBDIR)/libexecinfo ${ARGP_STANDALONE_CPPFLAGS} \

--- a/libglusterfs/src/glusterfs.h
+++ b/libglusterfs/src/glusterfs.h
@@ -350,6 +350,7 @@ struct _cmd_args {
         char            *sock_file;
         int              no_daemon_mode;
         char            *run_id;
+        char            *xlator_dir;
         int              debug_mode;
         int              read_only;
         int              acl;

--- a/libglusterfs/src/glusterfs.h
+++ b/libglusterfs/src/glusterfs.h
@@ -570,13 +570,14 @@ int glusterfs_graph_deactivate (glusterfs_graph_t *graph);
 int glusterfs_graph_destroy (glusterfs_graph_t *graph);
 int glusterfs_get_leaf_count (glusterfs_graph_t *graph);
 int glusterfs_graph_activate (glusterfs_graph_t *graph, glusterfs_ctx_t *ctx);
-glusterfs_graph_t *glusterfs_graph_construct (FILE *fp);
+glusterfs_graph_t *glusterfs_graph_construct (FILE *fp, glusterfs_ctx_t *ctx);
 int glusterfs_graph_init (glusterfs_graph_t *graph);
 glusterfs_graph_t *glusterfs_graph_new (void);
 int glusterfs_graph_reconfigure (glusterfs_graph_t *oldgraph,
                                   glusterfs_graph_t *newgraph);
 int glusterfs_graph_attach (glusterfs_graph_t *orig_graph, char *path,
-                            glusterfs_graph_t **newgraph);
+                            glusterfs_graph_t **newgraph,
+                            glusterfs_ctx_t *ctx);
 int glusterfs_graph_parent_up (glusterfs_graph_t *graph);
 
 void

--- a/libglusterfs/src/graph.c
+++ b/libglusterfs/src/graph.c
@@ -881,12 +881,12 @@ glusterfs_volfile_reconfigure (int oldvollen, FILE *newvolfile_fp,
                         goto out;
                 }
 
-                oldvolfile_graph = glusterfs_graph_construct (oldvolfile_fp);
+                oldvolfile_graph = glusterfs_graph_construct (oldvolfile_fp, ctx);
                 if (!oldvolfile_graph)
                         goto out;
         }
 
-        newvolfile_graph = glusterfs_graph_construct (newvolfile_fp);
+        newvolfile_graph = glusterfs_graph_construct (newvolfile_fp, ctx);
         if (!newvolfile_graph) {
                 goto out;
         }
@@ -1033,7 +1033,7 @@ out:
 
 int
 glusterfs_graph_attach (glusterfs_graph_t *orig_graph, char *path,
-                        glusterfs_graph_t **newgraph)
+                        glusterfs_graph_t **newgraph, glusterfs_ctx_t *ctx)
 {
         xlator_t                *this   = THIS;
         FILE                    *fp;
@@ -1052,7 +1052,7 @@ glusterfs_graph_attach (glusterfs_graph_t *orig_graph, char *path,
                 return -EIO;
         }
 
-        graph = glusterfs_graph_construct (fp);
+        graph = glusterfs_graph_construct (fp, ctx);
         fclose(fp);
         if (!graph) {
                 gf_log (this->name, GF_LOG_WARNING,

--- a/libglusterfs/src/graph.y
+++ b/libglusterfs/src/graph.y
@@ -76,6 +76,7 @@ WORD: ID | STRING_TOK ;
 
 xlator_t *curr;
 glusterfs_graph_t *construct;
+glusterfs_ctx_t *global_ctx;
 
 
 static void
@@ -163,6 +164,8 @@ new_volume (char *name)
                 ret = -1;
                 goto out;
         }
+
+        curr->ctx = global_ctx;
 
         curr->options = get_new_dict ();
 
@@ -549,7 +552,7 @@ glusterfs_graph_new ()
 
 
 glusterfs_graph_t *
-glusterfs_graph_construct (FILE *fp)
+glusterfs_graph_construct (FILE *fp, glusterfs_ctx_t *ctx)
 {
         int                ret = 0;
         int                tmp_fd = -1;
@@ -557,6 +560,8 @@ glusterfs_graph_construct (FILE *fp)
         FILE              *tmp_file = NULL;
         char               template[PATH_MAX] = {0};
 	static pthread_mutex_t graph_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+        global_ctx = ctx;
 
         graph = glusterfs_graph_new ();
         if (!graph)

--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -190,15 +190,26 @@ xlator_dynload (xlator_t *xl)
 {
         int                ret = -1;
         char              *name = NULL;
+        char              *xlator_dir = NULL;
         void              *handle = NULL;
         volume_opt_list_t *vol_opt = NULL;
         class_methods_t   *vtbl = NULL;
+        glusterfs_ctx_t   *ctx = NULL;
 
         GF_VALIDATE_OR_GOTO ("xlator", xl, out);
 
         INIT_LIST_HEAD (&xl->volume_options);
 
-        ret = gf_asprintf (&name, "%s/%s.so", XLATORDEFAULTDIR, xl->type);
+        ctx = xl->ctx;
+        if (ctx) {
+            xlator_dir = ctx->cmd_args.xlator_dir;
+        }
+
+        if (!xlator_dir) {
+            xlator_dir = XLATORDEFAULTDIR;
+        }
+
+        ret = gf_asprintf (&name, "%s/%s.so", xlator_dir, xl->type);
         if (-1 == ret) {
                 goto out;
         }

--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -145,7 +145,7 @@ xlator_volopt_dynload (char *xlator_type, void **dl_handle,
         /* socket.so doesn't fall under the default xlator directory, hence we
          * need this check */
         if (!strstr(xlator_type, "rpc-transport"))
-                ret = gf_asprintf (&name, "%s/%s.so", XLATORDIR, xlator_type);
+                ret = gf_asprintf (&name, "%s/%s.so", XLATORDEFAULTDIR, xlator_type);
         else
                 ret = gf_asprintf (&name, "%s/%s.so", XLATORPARENTDIR, xlator_type);
         if (-1 == ret) {
@@ -198,7 +198,7 @@ xlator_dynload (xlator_t *xl)
 
         INIT_LIST_HEAD (&xl->volume_options);
 
-        ret = gf_asprintf (&name, "%s/%s.so", XLATORDIR, xl->type);
+        ret = gf_asprintf (&name, "%s/%s.so", XLATORDEFAULTDIR, xl->type);
         if (-1 == ret) {
                 goto out;
         }

--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -134,20 +134,30 @@ out:
 
 int
 xlator_volopt_dynload (char *xlator_type, void **dl_handle,
-                       volume_opt_list_t *opt_list)
+                       volume_opt_list_t *opt_list,
+                       glusterfs_ctx_t *ctx)
 {
         int                     ret = -1;
         char                    *name = NULL;
+        char                    *xlator_dir = NULL;
         void                    *handle = NULL;
 
         GF_VALIDATE_OR_GOTO ("xlator", xlator_type, out);
 
+        if (ctx) {
+                xlator_dir = ctx->cmd_args.xlator_dir;
+        }
+
+        if (!xlator_dir) {
+                xlator_dir = XLATORDEFAULTDIR;
+        }
+
         /* socket.so doesn't fall under the default xlator directory, hence we
          * need this check */
         if (!strstr(xlator_type, "rpc-transport"))
-                ret = gf_asprintf (&name, "%s/%s.so", XLATORDEFAULTDIR, xlator_type);
+                ret = gf_asprintf (&name, "%s/%s.so", xlator_dir, xlator_type);
         else
-                ret = gf_asprintf (&name, "%s/%s.so", XLATORPARENTDIR, xlator_type);
+                ret = gf_asprintf (&name, "%s/../%s.so", xlator_dir, xlator_type);
         if (-1 == ret) {
                 goto out;
         }
@@ -202,11 +212,11 @@ xlator_dynload (xlator_t *xl)
 
         ctx = xl->ctx;
         if (ctx) {
-            xlator_dir = ctx->cmd_args.xlator_dir;
+                xlator_dir = ctx->cmd_args.xlator_dir;
         }
 
         if (!xlator_dir) {
-            xlator_dir = XLATORDEFAULTDIR;
+                xlator_dir = XLATORDEFAULTDIR;
         }
 
         ret = gf_asprintf (&name, "%s/%s.so", xlator_dir, xl->type);

--- a/libglusterfs/src/xlator.h
+++ b/libglusterfs/src/xlator.h
@@ -1034,7 +1034,7 @@ int xlator_mem_acct_init (xlator_t *xl, int num_types);
 int is_gf_log_command (xlator_t *trans, const char *name, char *value);
 int glusterd_check_log_level (const char *value);
 int xlator_volopt_dynload (char *xlator_type, void **dl_handle,
-                           volume_opt_list_t *vol_opt_handle);
+                           volume_opt_list_t *vol_opt_handle, glusterfs_ctx_t *ctx);
 enum gf_hdsk_event_notify_op {
         GF_EN_DEFRAG_STATUS,
         GF_EN_MAX,

--- a/rpc/rpc-lib/src/Makefile.am
+++ b/rpc/rpc-lib/src/Makefile.am
@@ -16,7 +16,7 @@ libgfrpc_ladir = $(includedir)/glusterfs/rpc
 AM_CPPFLAGS = $(GF_CPPFLAGS) -I$(top_srcdir)/libglusterfs/src \
 	-I$(top_srcdir)/rpc/xdr/src \
 	-I$(top_builddir)/rpc/xdr/src \
-	-DRPC_TRANSPORTDIR=\"$(libdir)/glusterfs/$(PACKAGE_VERSION)/rpc-transport\" \
+	-DRPC_TRANSPORTDIR=\"$(libdir)/glusterfs/rpc-transport\" \
 	-I$(top_srcdir)/contrib/rbtree
 
 AM_CFLAGS = -Wall $(GF_CFLAGS)

--- a/rpc/rpc-lib/src/rpc-transport.c
+++ b/rpc/rpc-lib/src/rpc-transport.c
@@ -270,7 +270,12 @@ rpc_transport_load (glusterfs_ctx_t *ctx, dict_t *options, char *trans_name)
 		goto fail;
 	}
 
-	ret = gf_asprintf (&name, "%s/%s.so", RPC_TRANSPORTDIR, type);
+        if (ctx && ctx->cmd_args.xlator_dir) {
+                ret = gf_asprintf (&name, "%s/../rpc-transport/%s.so", ctx->cmd_args.xlator_dir, type);
+        } else {
+                ret = gf_asprintf (&name, "%s/%s.so", RPC_TRANSPORTDIR, type);
+        }
+
         if (-1 == ret) {
                 goto fail;
         }

--- a/rpc/rpc-transport/rdma/src/Makefile.am
+++ b/rpc/rpc-transport/rdma/src/Makefile.am
@@ -1,7 +1,7 @@
 # TODO : need to change transportdir
 
 transport_LTLIBRARIES = rdma.la
-transportdir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/rpc-transport
+transportdir = $(libdir)/glusterfs/rpc-transport
 
 rdma_la_LDFLAGS = -module -avoid-version -nostartfiles
 

--- a/rpc/rpc-transport/socket/src/Makefile.am
+++ b/rpc/rpc-transport/socket/src/Makefile.am
@@ -1,7 +1,7 @@
 noinst_HEADERS = socket.h name.h socket-mem-types.h
 
 rpctransport_LTLIBRARIES = socket.la
-rpctransportdir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/rpc-transport
+rpctransportdir = $(libdir)/glusterfs/rpc-transport
 
 socket_la_LDFLAGS = -module -avoid-version
 

--- a/xlators/cluster/afr/src/Makefile.am
+++ b/xlators/cluster/afr/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = afr.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/cluster
+xlatordir = $(libdir)/glusterfs/xlator/cluster
 
 afr_common_source = afr-dir-read.c afr-dir-write.c afr-inode-read.c \
 	afr-inode-write.c afr-open.c afr-transaction.c afr-lk-common.c \

--- a/xlators/cluster/dht/src/Makefile.am
+++ b/xlators/cluster/dht/src/Makefile.am
@@ -5,7 +5,7 @@ endif
 
 AM_CFLAGS = -Wall $(GF_CFLAGS)
 
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/cluster
+xlatordir = $(libdir)/glusterfs/xlator/cluster
 
 dht_common_source = dht-layout.c dht-helper.c dht-linkfile.c dht-rebalance.c \
 	dht-selfheal.c dht-rename.c dht-hashfn.c dht-diskusage.c \

--- a/xlators/cluster/ec/src/Makefile.am
+++ b/xlators/cluster/ec/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = ec.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/cluster
+xlatordir = $(libdir)/glusterfs/xlator/cluster
 
 ec_sources := ec.c
 ec_sources += ec-data.c

--- a/xlators/cluster/stripe/src/Makefile.am
+++ b/xlators/cluster/stripe/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = stripe.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/cluster
+xlatordir = $(libdir)/glusterfs/xlator/cluster
 
 stripe_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/debug/error-gen/src/Makefile.am
+++ b/xlators/debug/error-gen/src/Makefile.am
@@ -1,6 +1,6 @@
 
 xlator_LTLIBRARIES = error-gen.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/debug
+xlatordir = $(libdir)/glusterfs/xlator/debug
 
 error_gen_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/debug/io-stats/src/Makefile.am
+++ b/xlators/debug/io-stats/src/Makefile.am
@@ -1,6 +1,6 @@
 
 xlator_LTLIBRARIES = io-stats.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/debug
+xlatordir = $(libdir)/glusterfs/xlator/debug
 
 io_stats_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/debug/trace/src/Makefile.am
+++ b/xlators/debug/trace/src/Makefile.am
@@ -1,6 +1,6 @@
 
 xlator_LTLIBRARIES = trace.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/debug
+xlatordir = $(libdir)/glusterfs/xlator/debug
 
 trace_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/encryption/crypt/src/Makefile.am
+++ b/xlators/encryption/crypt/src/Makefile.am
@@ -1,7 +1,7 @@
 if ENABLE_CRYPT_XLATOR
 
 xlator_LTLIBRARIES = crypt.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/encryption
+xlatordir = $(libdir)/glusterfs/xlator/encryption
 
 crypt_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/encryption/rot-13/src/Makefile.am
+++ b/xlators/encryption/rot-13/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = rot-13.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/encryption
+xlatordir = $(libdir)/glusterfs/xlator/encryption
 
 rot_13_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/features/arbiter/src/Makefile.am
+++ b/xlators/features/arbiter/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = arbiter.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 arbiter_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/features/barrier/src/Makefile.am
+++ b/xlators/features/barrier/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = barrier.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 barrier_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/features/bit-rot/src/bitd/Makefile.am
+++ b/xlators/features/bit-rot/src/bitd/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = bit-rot.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 bit_rot_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/features/bit-rot/src/stub/Makefile.am
+++ b/xlators/features/bit-rot/src/stub/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = bitrot-stub.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 bitrot_stub_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/features/changelog/src/Makefile.am
+++ b/xlators/features/changelog/src/Makefile.am
@@ -1,6 +1,6 @@
 xlator_LTLIBRARIES = changelog.la
 
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 noinst_HEADERS = changelog-helpers.h changelog-mem-types.h changelog-rt.h \
 	changelog-rpc-common.h changelog-misc.h changelog-encoders.h \

--- a/xlators/features/changetimerecorder/src/Makefile.am
+++ b/xlators/features/changetimerecorder/src/Makefile.am
@@ -1,4 +1,4 @@
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 # changetimerecorder can only get build when libgfdb is enabled
 if BUILD_GFDB

--- a/xlators/features/compress/src/Makefile.am
+++ b/xlators/features/compress/src/Makefile.am
@@ -1,6 +1,6 @@
 xlator_LTLIBRARIES = cdc.la
 
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 noinst_HEADERS = cdc.h cdc-mem-types.h
 

--- a/xlators/features/gfid-access/src/Makefile.am
+++ b/xlators/features/gfid-access/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = gfid-access.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 gfid_access_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/features/glupy/examples/Makefile.am
+++ b/xlators/features/glupy/examples/Makefile.am
@@ -1,4 +1,4 @@
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 glupyexamplesdir = $(xlatordir)/glupy
 

--- a/xlators/features/glupy/src/Makefile.am
+++ b/xlators/features/glupy/src/Makefile.am
@@ -1,7 +1,7 @@
 xlator_LTLIBRARIES = glupy.la
 
 # Ensure GLUSTER_PYTHON_PATH is passed to glupy.so
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 glupydir = $(xlatordir)/glupy
 
 AM_CPPFLAGS = $(PYTHONDEV_CPPFLAGS) $(GF_CPPFLAGS) \

--- a/xlators/features/index/src/Makefile.am
+++ b/xlators/features/index/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = index.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 index_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/features/leases/src/Makefile.am
+++ b/xlators/features/leases/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = leases.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 leases_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/features/locks/src/Makefile.am
+++ b/xlators/features/locks/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = locks.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 locks_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/features/marker/src/Makefile.am
+++ b/xlators/features/marker/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = marker.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 marker_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/features/quiesce/src/Makefile.am
+++ b/xlators/features/quiesce/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = quiesce.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 quiesce_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/features/quota/src/Makefile.am
+++ b/xlators/features/quota/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = quota.la quotad.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 quota_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 quotad_la_LDFLAGS = -module -avoid-version -export-symbols $(top_srcdir)/xlators/features/quota/src/quotad.sym

--- a/xlators/features/read-only/src/Makefile.am
+++ b/xlators/features/read-only/src/Makefile.am
@@ -1,6 +1,6 @@
 xlator_LTLIBRARIES = read-only.la worm.la
 
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 noinst_HEADERS = read-only.h read-only-mem-types.h read-only-common.h worm-helper.h
 

--- a/xlators/features/shard/src/Makefile.am
+++ b/xlators/features/shard/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = shard.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 shard_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/features/snapview-client/src/Makefile.am
+++ b/xlators/features/snapview-client/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = snapview-client.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 snapview_client_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/features/snapview-server/src/Makefile.am
+++ b/xlators/features/snapview-server/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = snapview-server.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 snapview_server_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/features/trash/src/Makefile.am
+++ b/xlators/features/trash/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = trash.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 trash_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/features/upcall/src/Makefile.am
+++ b/xlators/features/upcall/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = upcall.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
+xlatordir = $(libdir)/glusterfs/xlator/features
 
 upcall_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/meta/src/Makefile.am
+++ b/xlators/meta/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = meta.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator
+xlatordir = $(libdir)/glusterfs/xlator
 
 meta_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/mgmt/glusterd/src/Makefile.am
+++ b/xlators/mgmt/glusterd/src/Makefile.am
@@ -1,6 +1,6 @@
 xlator_LTLIBRARIES = glusterd.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/mgmt
-glusterd_la_CPPFLAGS = $(AM_CPPFLAGS) "-DFILTERDIR=\"$(libdir)/glusterfs/$(PACKAGE_VERSION)/filter\""
+xlatordir = $(libdir)/glusterfs/xlator/mgmt
+glusterd_la_CPPFLAGS = $(AM_CPPFLAGS) "-DFILTERDIR=\"$(libdir)/glusterfs/filter\""
 glusterd_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 glusterd_la_SOURCES = glusterd.c glusterd-handler.c glusterd-sm.c \
 	glusterd-op-sm.c glusterd-utils.c glusterd-rpc-ops.c \

--- a/xlators/mgmt/glusterd/src/glusterd-quota.c
+++ b/xlators/mgmt/glusterd/src/glusterd-quota.c
@@ -1817,7 +1817,7 @@ _glusterd_validate_quota_opts (dict_t *dict, int type, char **errstr)
         GF_ASSERT (dict);
         GF_ASSERT (this);
 
-        ret = xlator_volopt_dynload ("features/quota", &quota_xl, &opt_list);
+        ret = xlator_volopt_dynload ("features/quota", &quota_xl, &opt_list, this->ctx);
         if (ret)
                 goto out;
 

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -8539,12 +8539,12 @@ glusterd_check_topology_identical (const char   *filename1,
         }
 
         /* create the graph for filename1 */
-        grph1 = glusterfs_graph_construct(fp1);
+        grph1 = glusterfs_graph_construct(fp1, NULL);
         if (grph1 == NULL)
                 goto out;
 
         /* create the graph for filename2 */
-        grph2 = glusterfs_graph_construct(fp2);
+        grph2 = glusterfs_graph_construct(fp2, NULL);
         if (grph2 == NULL)
                 goto out;
 

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -11974,7 +11974,7 @@ glusterd_get_value_for_vme_entry (struct volopt_map_entry *vme, char **def_val)
                 goto out;
         }
 
-        ret = xlator_volopt_dynload (vme->voltype, &dl_handle, &vol_opt_handle);
+        ret = xlator_volopt_dynload (vme->voltype, &dl_handle, &vol_opt_handle, this->ctx);
         if (ret) {
                 gf_msg (this->name, GF_LOG_ERROR, 0,
                         GD_MSG_XLATOR_VOLOPT_DYNLOAD_ERROR,
@@ -12362,7 +12362,8 @@ glusterd_get_volopt_content (dict_t * ctx, gf_boolean_t xml_out)
 
                         ret = xlator_volopt_dynload (vme->voltype,
                                                      &dl_handle,
-                                                     &vol_opt_handle);
+                                                     &vol_opt_handle,
+                                                     ctx);
 
                         if (ret) {
                                 gf_msg_debug ("glusterd", 0,

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.c
@@ -6637,15 +6637,18 @@ _gd_get_option_type (char *key)
         volume_option_t         *opt = NULL;
         char                    *xlopt_key = NULL;
         volume_option_type_t    opt_type = GF_OPTION_TYPE_MAX;
+        xlator_t                *this = NULL;
 
         GF_ASSERT (key);
+        GF_ASSERT (THIS);
 
+        this = THIS;
         vmep = _gd_get_vmep (key);
 
         if (vmep) {
                 CDS_INIT_LIST_HEAD (&vol_opt_list.list);
                 ret = xlator_volopt_dynload (vmep->voltype, &dl_handle,
-                                             &vol_opt_list);
+                                             &vol_opt_list, this->ctx);
                 if (ret)
                         goto out;
 

--- a/xlators/mount/fuse/src/Makefile.am
+++ b/xlators/mount/fuse/src/Makefile.am
@@ -15,7 +15,7 @@ else
 endif
 
 xlator_LTLIBRARIES = fuse.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/mount
+xlatordir = $(libdir)/glusterfs/xlator/mount
 
 if GF_DARWIN_HOST_OS
     mount_source=$(CONTRIBDIR)/macfuse/mount_darwin.c

--- a/xlators/nfs/server/src/Makefile.am
+++ b/xlators/nfs/server/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = server.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/nfs
+xlatordir = $(libdir)/glusterfs/xlator/nfs
 nfsrpclibdir = $(top_srcdir)/rpc/rpc-lib/src
 server_la_LDFLAGS = -module -avoid-version -export-symbols \
 	$(top_srcdir)/xlators/nfs/server/src/nfsserver.sym
@@ -17,7 +17,7 @@ noinst_HEADERS = nfs.h nfs-common.h nfs-fops.h nfs-inodes.h nfs-generics.h \
 	acl3.h netgroups.h exports.h mount3-auth.h auth-cache.h nfs-messages.h
 
 AM_CPPFLAGS = $(GF_CPPFLAGS) \
-	-DLIBDIR=\"$(libdir)/glusterfs/$(PACKAGE_VERSION)/auth\" \
+	-DLIBDIR=\"$(libdir)/glusterfs/auth\" \
 	-I$(top_srcdir)/libglusterfs/src -I$(top_srcdir)/api/src \
 	-I$(top_srcdir)/rpc/xdr/src/ -I$(top_builddir)/rpc/xdr/src/ \
 	-I$(nfsrpclibdir) -I$(CONTRIBDIR)/rbtree \

--- a/xlators/performance/decompounder/src/Makefile.am
+++ b/xlators/performance/decompounder/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = decompounder.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/performance
+xlatordir = $(libdir)/glusterfs/xlator/performance
 
 decompounder_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/performance/io-cache/src/Makefile.am
+++ b/xlators/performance/io-cache/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = io-cache.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/performance
+xlatordir = $(libdir)/glusterfs/xlator/performance
 
 io_cache_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/performance/io-threads/src/Makefile.am
+++ b/xlators/performance/io-threads/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = io-threads.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/performance
+xlatordir = $(libdir)/glusterfs/xlator/performance
 
 io_threads_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/performance/md-cache/src/Makefile.am
+++ b/xlators/performance/md-cache/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = md-cache.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/performance
+xlatordir = $(libdir)/glusterfs/xlator/performance
 
 md_cache_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 
@@ -18,12 +18,12 @@ CLEANFILES =
 
 
 stat-prefetch-compat:
-	mkdir -p $(DESTDIR)$(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/performance
-	rm -rf $(DESTDIR)$(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/performance/stat-prefetch.so
-	ln -s ./md-cache.so $(DESTDIR)$(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/performance/stat-prefetch.so
+	mkdir -p $(DESTDIR)$(libdir)/glusterfs/xlator/performance
+	rm -rf $(DESTDIR)$(libdir)/glusterfs/xlator/performance/stat-prefetch.so
+	ln -s ./md-cache.so $(DESTDIR)$(libdir)/glusterfs/xlator/performance/stat-prefetch.so
 
 
 install-exec-local: stat-prefetch-compat
 
 uninstall-local:
-	rm -f $(DESTDIR)$(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/performance/stat-prefetch.so
+	rm -f $(DESTDIR)$(libdir)/glusterfs/xlator/performance/stat-prefetch.so

--- a/xlators/performance/open-behind/src/Makefile.am
+++ b/xlators/performance/open-behind/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = open-behind.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/performance
+xlatordir = $(libdir)/glusterfs/xlator/performance
 
 open_behind_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/performance/quick-read/src/Makefile.am
+++ b/xlators/performance/quick-read/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = quick-read.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/performance
+xlatordir = $(libdir)/glusterfs/xlator/performance
 
 quick_read_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/performance/read-ahead/src/Makefile.am
+++ b/xlators/performance/read-ahead/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = read-ahead.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/performance
+xlatordir = $(libdir)/glusterfs/xlator/performance
 
 read_ahead_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/performance/readdir-ahead/src/Makefile.am
+++ b/xlators/performance/readdir-ahead/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = readdir-ahead.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/performance
+xlatordir = $(libdir)/glusterfs/xlator/performance
 
 readdir_ahead_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/performance/symlink-cache/src/Makefile.am
+++ b/xlators/performance/symlink-cache/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = symlink-cache.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/testing/performance
+xlatordir = $(libdir)/glusterfs/xlator/testing/performance
 
 symlink_cache_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/performance/write-behind/src/Makefile.am
+++ b/xlators/performance/write-behind/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = write-behind.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/performance
+xlatordir = $(libdir)/glusterfs/xlator/performance
 
 write_behind_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/playground/template/src/Makefile.am
+++ b/xlators/playground/template/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = template.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/testing/features
+xlatordir = $(libdir)/glusterfs/xlator/testing/features
 
 template_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/protocol/auth/addr/src/Makefile.am
+++ b/xlators/protocol/auth/addr/src/Makefile.am
@@ -1,5 +1,5 @@
 auth_LTLIBRARIES = addr.la
-authdir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/auth
+authdir = $(libdir)/glusterfs/auth
 
 addr_la_LDFLAGS = -module -avoid-version
 

--- a/xlators/protocol/auth/login/src/Makefile.am
+++ b/xlators/protocol/auth/login/src/Makefile.am
@@ -1,5 +1,5 @@
 auth_LTLIBRARIES = login.la
-authdir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/auth
+authdir = $(libdir)/glusterfs/auth
 
 login_la_LDFLAGS = -module -avoid-version
 

--- a/xlators/protocol/client/src/Makefile.am
+++ b/xlators/protocol/client/src/Makefile.am
@@ -1,6 +1,6 @@
 
 xlator_LTLIBRARIES = client.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/protocol
+xlatordir = $(libdir)/glusterfs/xlator/protocol
 
 client_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/protocol/server/src/Makefile.am
+++ b/xlators/protocol/server/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = server.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/protocol
+xlatordir = $(libdir)/glusterfs/xlator/protocol
 
 server_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 
@@ -17,7 +17,7 @@ server_ladir = $(includedir)/glusterfs/server
 
 AM_CPPFLAGS = $(GF_CPPFLAGS) -I$(top_srcdir)/libglusterfs/src \
 	-DCONFDIR=\"$(sysconfdir)/glusterfs\" \
-	-DLIBDIR=\"$(libdir)/glusterfs/$(PACKAGE_VERSION)/auth\" \
+	-DLIBDIR=\"$(libdir)/glusterfs/auth\" \
 	-I$(top_srcdir)/xlators/protocol/lib/src \
 	-I$(top_srcdir)/rpc/rpc-lib/src \
 	-I$(top_srcdir)/rpc/xdr/src -I$(top_builddir)/rpc/xdr/src

--- a/xlators/storage/bd/src/Makefile.am
+++ b/xlators/storage/bd/src/Makefile.am
@@ -1,6 +1,6 @@
 if ENABLE_BD_XLATOR
 xlator_LTLIBRARIES = bd.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/storage
+xlatordir = $(libdir)/glusterfs/xlator/storage
 
 bd_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 LIBBD = -llvm2app -lrt

--- a/xlators/storage/posix/src/Makefile.am
+++ b/xlators/storage/posix/src/Makefile.am
@@ -1,6 +1,6 @@
 
 xlator_LTLIBRARIES = posix.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/storage
+xlatordir = $(libdir)/glusterfs/xlator/storage
 
 posix_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 

--- a/xlators/system/posix-acl/src/Makefile.am
+++ b/xlators/system/posix-acl/src/Makefile.am
@@ -1,5 +1,5 @@
 xlator_LTLIBRARIES = posix-acl.la
-xlatordir = $(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/system
+xlatordir = $(libdir)/glusterfs/xlator/system
 posix_acl_la_LDFLAGS = -module $(GF_XLATOR_DEFAULT_LDFLAGS)
 posix_acl_la_SOURCES = posix-acl.c posix-acl-xattr.c
 posix_acl_la_LIBADD = $(top_builddir)/libglusterfs/src/libglusterfs.la
@@ -17,12 +17,12 @@ AM_LDFLAGS = -L$(xlatordir)
 CLEANFILES =
 
 access-control-compat:
-	mkdir -p $(DESTDIR)$(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features
-	rm -rf $(DESTDIR)$(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features/access-control.so
-	ln -s ../system/posix-acl.so $(DESTDIR)$(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features/access-control.so
+	mkdir -p $(DESTDIR)$(libdir)/glusterfs/xlator/features
+	rm -rf $(DESTDIR)$(libdir)/glusterfs/xlator/features/access-control.so
+	ln -s ../system/posix-acl.so $(DESTDIR)$(libdir)/glusterfs/xlator/features/access-control.so
 
 
 install-exec-local: access-control-compat
 
 uninstall-local:
-	rm -f $(DESTDIR)$(libdir)/glusterfs/$(PACKAGE_VERSION)/xlator/features/access-control.so
+	rm -f $(DESTDIR)$(libdir)/glusterfs/xlator/features/access-control.so


### PR DESCRIPTION
In order to support a more self-contained installation of glusterfs, this adds an --xlator-dir option to glusterfsd. By default, --xlator-dir is set to `$(libdir)/glusterfs/xlator`.

This relies on passing in a glusterfs_ctx to the two xlator_dynload functions.

As a precaution for upgrades, this also removes `$PACKAGE_VERSION` from the xlator path (it is impossible to have glusterfs installations side by side within the same $prefix anyways, and it risks that xlator dir is not updated as it needs to be on every upgrade).

This is based off of https://github.com/glusterfs/glusterfs/releases/tag/v3.10.10, so is merging into a target branch based off of that tag. Git will be used to generate full patches.
