### PR TITLE
Support configurable run-directory and log-directory

### DIFF
--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -563,7 +563,7 @@ typedef enum {
 #define GLUSTERD_MISSED_SNAPS_LIST_FILE "missed_snaps_list"
 #define GLUSTERD_VOL_SNAP_DIR_PREFIX "snaps"
 
-#define GLUSTERD_DEFAULT_SNAPS_BRICK_DIR     "/gluster/snaps"
+#define GLUSTERD_DEFAULT_SNAPS_BRICK_DIR     "/snaps"
 #define GLUSTERD_BITD_RUN_DIR                "/bitd"
 #define GLUSTERD_SCRUB_RUN_DIR               "/scrub"
 #define GLUSTERD_GLUSTERSHD_RUN_DIR          "/glustershd"
@@ -571,7 +571,6 @@ typedef enum {
 #define GLUSTERD_QUOTAD_RUN_DIR              "/quotad"
 #define GLUSTER_SHARED_STORAGE_BRICK_DIR     GLUSTERD_DEFAULT_WORKDIR"/ss_brick"
 #define GLUSTERD_VAR_RUN_DIR                 "/var/run"
-#define GLUSTERD_RUN_DIR                     "/run"
 
 /* definitions related to replace brick */
 #define RB_CLIENT_MOUNTPOINT    "rb_mount"


### PR DESCRIPTION
Formally support these two options. run-directory already existed, but was not used in the case of /var/run/gluster/snaps because it needed to not include a symlink. Use realpath to resolve that issue.
log-directory was not configurable, despite the command line having some log file options, so this provides that level of control.