### PR TITLE
Support --xlator-dir= in gluster cli

### DIFF
--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -408,6 +408,12 @@ cli_opt_parse (char *opt, struct cli_state *state)
                 return 0;
         }
 
+        oarg = strtail (opt, "xlator-dir=");
+        if (oarg) {
+                state->ctx->cmd_args.xlator_dir = oarg;
+                return 0;
+        }
+
         oarg = strtail (opt, "secure-mgmt=");
         if (oarg) {
                 if (gf_string2boolean(oarg,&secure_mgmt_tmp) == 0) {


### PR DESCRIPTION
Add the equivalent --xlator-dir to the glusterfs client cli.